### PR TITLE
#14640 Support lowercase yyyy in to_char

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/formatting/DateTimeFormatter.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/DateTimeFormatter.java
@@ -70,6 +70,7 @@ public class DateTimeFormatter {
         P_M_LOWER("p.m."),
         YEAR_WITH_COMMA("Y,YYY"),
         YEAR_YYYY("YYYY"),
+        YEAR_LOWER_YYYY("yyyy"),
         YEAR_YYY("YYY"),
         YEAR_YY("YY"),
         YEAR_Y("Y"),
@@ -300,7 +301,7 @@ public class DateTimeFormatter {
                 String s = String.valueOf(datetime.getYear());
                 yield s.substring(0, 1) + "," + s.substring(1);
             }
-            case YEAR_YYYY -> padStart(String.valueOf(datetime.getYear()), 4, '0');
+            case YEAR_YYYY, YEAR_LOWER_YYYY -> padStart(String.valueOf(datetime.getYear()), 4, '0');
             case YEAR_YYY -> {
                 String s = padStart(String.valueOf(datetime.getYear()), 4, '0');
                 yield s.substring(s.length() - 3);

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
@@ -40,6 +40,14 @@ public class ToCharFunctionTest extends ScalarTestCase {
     }
 
     @Test
+    public void test_lower_case_yyyy_supported() throws Exception {
+        assertEvaluate("to_char(timestamp '1970-01-01', 'yyyy')", "1970");
+        assertEvaluate("to_char(timestamp '1971-01-01T17:31:12', 'yyyy')", "1971");
+        assertEvaluate("to_char(interval '2 year', 'yyyy')", "0002");
+        assertEvaluate("to_char(INTERVAL '1 year 2 months 3 weeks 5 hours 6 minutes 7 seconds', 'yyyy')", "0001");
+    }
+
+    @Test
     public void testEvaluateTimestampWithNullPattern() {
         assertEvaluateNull("to_char(timestamp '1970-01-01T17:31:12', null)");
     }


### PR DESCRIPTION
Added lowercase 'yyyy' to Token enum, added lowercase 'yyyy' case to getElement, and added four test cases for supporting lowercase 'yyyy' in to_char tests. These changes support issue #14640 (Support lowercase yyyy in to_char).




